### PR TITLE
[TASK] Add DDEV v1.24 and latest/nightly to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ v1.23, v1.22 ]
+        version: [ v1.24, v1.23, v1.22 ]
     steps:
       -
         name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ v1.24, v1.23, v1.22 ]
+        version: [ latest, v1.24, v1.23, v1.22 ]
     steps:
       -
         name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ v1.24, v1.23, v1.22 ]
+        version: [ latest, v1.24, v1.23, v1.22 ]
     steps:
       -
         name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ v1.23, v1.22 ]
+        version: [ v1.24, v1.23, v1.22 ]
     steps:
       -
         name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ARG ddev_version
 ENV DDEV_VERSION=${ddev_version}
 
 COPY ddev-install.sh ddev-install.sh
-RUN ash ddev-install.sh && rm ddev-install.sh
+RUN ash ddev-install.sh
 USER ddev
 RUN mkcert -install

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Available options:
 
 | Command               | Tags to be created             |
 |-----------------------|--------------------------------|
+| ./build.sh -v latest  | latest (aka head/nightly)      |
 | ./build.sh -v v1.22   | v1.22, v1.22.x (latest bugfix) |
 | ./build.sh -v v1.22.5 | v1.22.5                        |
 | ./build.sh -v v1.23   | v1.23, v1.23.x (latest bugfix) |

--- a/build.sh
+++ b/build.sh
@@ -69,13 +69,22 @@ while getopts ":v:hplx" opt; do
     PLATFORM="--platform linux/amd64,linux/arm64"
     ;;
   *)
-    echo "Invalid option: -$OPTARG"
     help
+    echo "Invalid option: -$OPTARG"
     exit 1
     ;;
   esac
 done
 
-loadVersionAndTags
+# Set version and tag for latest (aka nightly)
+if [ "$OPTION_VERSION" = "latest" ]; then
+  DDEV_VERSION="latest"
+  DOCKER_TAGS=("-t $IMAGE_NAME:latest")
+else
+  loadVersionAndTags
+fi
+
+echo $DDEV_VERSION
+echo $DOCKER_TAGS
 
 docker buildx build ${PLATFORM} --progress plain --no-cache --pull . -f Dockerfile ${DOCKER_TAGS[@]} --build-arg ddev_version="$DDEV_VERSION" $PUSH $LOAD

--- a/ddev-install.sh
+++ b/ddev-install.sh
@@ -20,15 +20,29 @@ case ${unamearch} in
 ;;
 esac
 
-wget "https://github.com/ddev/ddev/releases/download/${DDEV_VERSION}/ddev_linux-${ARCH}.${DDEV_VERSION}.tar.gz"
-
 # Prepare and install binaries
 mkdir ddev
-tar xfvz "ddev_linux-${ARCH}.${DDEV_VERSION}.tar.gz" --directory ddev
+
+if [ "$DDEV_VERSION" = "latest" ]; then
+  # Download ddev head (nightly)
+  wget "https://nightly.link/ddev/ddev/workflows/master-build/master/all-ddev-executables.zip"
+
+  unzip all-ddev-executables.zip
+  tar xfvz ddev_linux-${ARCH}.* --directory ddev
+  # Extract nightly version from file name
+  LAST_STARTED_VERSION=$(find ddev_linux-${ARCH}* | sed -n "s/.*ddev_linux-${ARCH}\.\(.*\)\.tar\.gz/\1/p")
+else
+  # Download specific ddev version
+  wget "https://github.com/ddev/ddev/releases/download/${DDEV_VERSION}/ddev_linux-${ARCH}.${DDEV_VERSION}.tar.gz"
+
+  tar xfvz "ddev_linux-${ARCH}.${DDEV_VERSION}.tar.gz" --directory ddev
+  LAST_STARTED_VERSION=${DDEV_VERSION}
+fi
+
 mv ddev/ddev /usr/local/bin/
 mv ddev/mkcert /usr/local/bin/
 sudo -i ddev /usr/local/bin/mkcert -install
-rm -Rf ddev "ddev_linux-${ARCH}.${DDEV_VERSION}.tar.gz"
+rm -Rf ddev*
 
 # Ensure required folders exist
 mkdir -p /home/ddev/.ddev/commands/host
@@ -37,7 +51,7 @@ disable_http2: false
 fail_on_hook_fail: false
 instrumentation_opt_in: false
 internet_detection_timeout_ms: 3000
-last_started_version: ${DDEV_VERSION}
+last_started_version: ${LAST_STARTED_VERSION}
 letsencrypt_email: ""
 mkcert_caroot: /home/ddev/.local/share/mkcert
 no_bind_mounts: false

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -12,9 +12,14 @@
 
 @test "See ddev version" {
     run docker-run "ddev version -j"
-
     version=$(echo "$output" | tail -n 1 | yq '.raw.["DDEV version"]')
-    regex='^v([0-9]+)\.([0-9]+)\.([0-9]+)$'
+
+    if [ "$DDEV_VERSION" = "latest" ]; then
+      # The HEAD version contains a hash e.g. v1.24.1-4-gbce95e65e
+      regex='^v([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)-([a-z0-9]+)$'
+    else
+      regex='^v([0-9]+)\.([0-9]+)\.([0-9]+)$'
+    fi
 
     [[ $version =~ $regex ]]
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Add DDEV 1.24 and latest/nightly to the list of versions to built docker images for.