### PR TITLE
fix: exclude v1.22 and v1.23 from builds because of Mutagen and Docker 28 error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ latest, v1.24, v1.23, v1.22 ]
+        version: [ latest, stable ]
     steps:
       -
         name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,16 +30,17 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
       -
-        name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.11.0
+        name: Setup bats and bats libs
+        id: setup-bats
+        uses: bats-core/bats-action@3.0.0
       -
         name: Check out code
         uses: actions/checkout@v1
       -
         name: "Test ddev ${{ matrix.version }} image"
         shell: 'script -q -e -c "bash {0}"'
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
         run: |
           sudo snap install yq
           ./build.sh -v ${{ matrix.version }} -l

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,16 +29,17 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
       -
-        name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.11.0
+        name: Setup bats and bats libs
+        id: setup-bats
+        uses: bats-core/bats-action@3.0.0
       -
         name: Check out code
         uses: actions/checkout@v1
       -
         name: "Test ddev ${{ matrix.version }} image"
         shell: 'script -q -e -c "bash {0}"'
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
         run: |
           sudo snap install yq
           ./build.sh -v ${{ matrix.version }} -l

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ latest, v1.24, v1.23, v1.22 ]
+        version: [ latest, v1.24 ]
     steps:
       -
         name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ latest, v1.24 ]
+        version: [ latest, stable ]
     steps:
       -
         name: Checkout code

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Both container engines work, but the required configuration is slightly differen
 ### Example configurations
 
 Depending on your setup, you want to pick one if the following example configurations.
- 
+
 * [gitlab.com](docs%2Fgitlab-com.md)
 * [Docker](docs%2Fdocker.md) (self-hosted)
 * [Podman](docs%2Fpodman.md) (self-hosted)
@@ -24,10 +24,10 @@ Build the image:
 
 ```bash
 ./build.sh -v <version, at least major.minor> -p
-``` 
+```
 
 Available options:
- * v - DDEV version e.g. 'v1.23.1' 
+ * v - DDEV version e.g. 'v1.23.1'
  * l - Load the image (--load)
  * p - Push the image (--push)
  * x - Build multi-arch image (--platform linux/amd64,linux/arm64)
@@ -37,12 +37,13 @@ Available options:
 | Command               | Tags to be created             |
 |-----------------------|--------------------------------|
 | ./build.sh -v latest  | latest (aka head/nightly)      |
+| ./build.sh -v stable  | stable, v1.x, v1.x.y (release) |
 | ./build.sh -v v1.22   | v1.22, v1.22.x (latest bugfix) |
 | ./build.sh -v v1.22.5 | v1.22.5                        |
 | ./build.sh -v v1.23   | v1.23, v1.23.x (latest bugfix) |
 | ...                   | ...                            |
 
-The image is stored on the [GitHub Package Registry](https://github.com/ddev/ddev-gitlab-ci/pkgs/container/ddev-gitlab-ci) 
+The image is stored on the [GitHub Package Registry](https://github.com/ddev/ddev-gitlab-ci/pkgs/container/ddev-gitlab-ci)
 
 ### Run tests locally
 

--- a/build.sh
+++ b/build.sh
@@ -80,6 +80,18 @@ done
 if [ "$OPTION_VERSION" = "latest" ]; then
   DDEV_VERSION="latest"
   DOCKER_TAGS=("-t $IMAGE_NAME:latest")
+elif [ "$OPTION_VERSION" = "stable" ]; then
+  DDEV_VERSION="$(curl --silent -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/ddev/ddev/releases/latest | jq -r '.tag_name')"
+
+  if [[ ! "$DDEV_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Latest DDEV release '$DDEV_VERSION' is not a valid semver version."
+    exit 2
+  fi
+
+  # Get version like v1.24
+  additional_tag="${DDEV_VERSION%.*}"
+
+  DOCKER_TAGS=("-t $IMAGE_NAME:stable" "-t $IMAGE_NAME:$additional_tag" "-t $IMAGE_NAME:$DDEV_VERSION")
 else
   loadVersionAndTags
 fi

--- a/ddev-install.sh
+++ b/ddev-install.sh
@@ -41,7 +41,7 @@ fi
 
 mv ddev/ddev /usr/local/bin/
 mv ddev/mkcert /usr/local/bin/
-sudo -i ddev /usr/local/bin/mkcert -install
+sudo -u ddev /usr/local/bin/mkcert -install
 rm -Rf ddev*
 
 # Ensure required folders exist

--- a/ddev-install.sh
+++ b/ddev-install.sh
@@ -25,7 +25,7 @@ mkdir ddev
 
 if [ "$DDEV_VERSION" = "latest" ]; then
   # Download ddev head (nightly)
-  wget "https://nightly.link/ddev/ddev/workflows/master-build/master/all-ddev-executables.zip"
+  wget "https://nightly.link/ddev/ddev/workflows/main-build/main/all-ddev-executables.zip"
 
   unzip all-ddev-executables.zip
   tar xfvz ddev_linux-${ARCH}.* --directory ddev

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+setup() {
+  TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+  export BATS_LIB_PATH="${BATS_LIB_PATH}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"
+  bats_load_library bats-assert
+  bats_load_library bats-file
+  bats_load_library bats-support
+}
+
 @test "See docker version" {
     run docker-run "docker version -f json"
 
@@ -28,8 +36,8 @@
 @test "See mkcert is installed" {
     run docker-run "mkcert -help"
 
-    [[ "$output" == *"Usage of mkcert:"* ]]
-    [ "$status" -eq 0 ]
+    assert_output --partial "Usage of mkcert:"
+    assert_success
 }
 
 @test "Create and run a ddev project" {
@@ -45,17 +53,17 @@
     "
     run docker-run "${TEST_COMMAND}"
 
-    [[ "$output" == *"Configuration complete. You may now run 'ddev start'"* ]]
-    [[ "$output" == *"Hello World"* ]]
-    [ "$status" -eq 0 ]
+    assert_output --partial "Configuration complete. You may now run 'ddev start'"
+    assert_output --partial "Hello World"
+    assert_success
 }
 
 @test "Run ddev debug dockercheck" {
     run docker-run "ddev debug dockercheck"
 
-    [[ "$output" == *"Able to run simple container that mounts a volume."* ]]
-    [[ "$output" == *"Able to use internet inside container."* ]]
-    [ "$status" -eq 0 ]
+    assert_output --partial "Able to run simple container that mounts a volume."
+    assert_output --partial "Able to use internet inside container."
+    assert_success
 }
 
 # Use "--no-bind-mounts=true" to make "ddev debug test" pass. This is only required in testing environment
@@ -69,8 +77,8 @@
     "
     run docker-run "${TEST_COMMAND}"
 
-    [[ "$output" == *"Successfully started tryddevproject-"* ]]
-    [ "$status" -eq 0 ]
+    assert_output --partial "Successfully started tryddevproject-"
+    assert_success
 }
 
 docker-run() {


### PR DESCRIPTION
## The Issue

Builds are failing.

- https://github.com/ddev/ddev-gitlab-ci/actions/runs/13754861857/job/38460629214

The reason why:

- https://github.com/ddev/ddev/issues/7015

## How This PR Solves The Issue

- Fixes `mkcert -install` https://github.com/ddev/ddev-gitlab-ci/actions/runs/13754861857/job/38460629214#step:8:253
- Uses correct artifacts for latest (`main`, not `master`), see https://github.com/ddev/ddev/pull/6876
- Uses bats libraries, because I couldn't see the error output to understand where is the problem
- Do not build v1.22 and v1.23 because tests use Mutagen and everything is built using `docker:latest`
- Add a `stable` tag, so we don't need to update it for each new major DDEV release.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

