### PR TITLE
build: use built-in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,15 @@ jobs:
           ./build.sh -v ${{ matrix.version }} -l
           DDEV_VERSION=${{ matrix.version }} bash bats tests
       -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
         name: "Build ddev ${{ matrix.version }} multi-arch image"
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker buildx create --use --platform=linux/arm64,linux/amd64
           ./build.sh -v ${{ matrix.version }} -x -p


### PR DESCRIPTION
## The Issue

The classic GitHub token (I don't even know which one) has expired:

https://github.com/ddev/ddev-gitlab-ci/actions/runs/14565414328

`#16 ERROR: failed to push ghcr.io/ddev/ddev-gitlab-ci:stable: failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://ghcr.io/token?scope=repository%3Addev%2Fddev-gitlab-ci%3Apull%2Cpush&service=ghcr.io: 403 Forbidden`

## How This PR Solves The Issue

Uses the default `GITHUB_TOKEN` provided by GitHub Actions, but the key thing is to allow the access:

See https://github.com/orgs/community/discussions/26274#discussioncomment-3251137

> head over to $yourOrganization → Packages → $yourPackage → Package settings (to the right / bottom)
> And configure “Manage Actions access” section to allow the git repository in question write permissions on this package/docker repository

---

https://github.com/orgs/ddev/packages/container/ddev-gitlab-ci/settings

![image](https://github.com/user-attachments/assets/696bf5b1-9496-4673-ad56-140a3bb6975e)

## Manual Testing Instructions

I already tested it in https://github.com/ddev/ddev-gitlab-ci/actions/runs/14577504841

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

