### PR TITLE
build: set `BUILDX_NO_DEFAULT_ATTESTATIONS=1`, fix warnings from bats, fixes #19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "Dockerfile"
+      - "build.sh"
+      - "ddev-install.sh"
+      - ".github/workflows/build.yml"
   schedule:
     - cron: "0 1 * * 1"
 
@@ -17,7 +22,7 @@ jobs:
     steps:
       -
         name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Docker info
         run: docker info
@@ -32,10 +37,12 @@ jobs:
       -
         name: Setup bats and bats libs
         id: setup-bats
-        uses: bats-core/bats-action@3.0.0
-      -
-        name: Check out code
-        uses: actions/checkout@v1
+        uses: bats-core/bats-action@3.0.1
+        with:
+          support-path: "${{ github.workspace }}/tests/bats-support"
+          assert-path: "${{ github.workspace }}/tests/bats-assert"
+          detik-path: "${{ github.workspace }}/tests/bats-detik"
+          file-path: "${{ github.workspace }}/tests/bats-file"
       -
         name: "Test ddev ${{ matrix.version }} image"
         shell: 'script -q -e -c "bash {0}"'
@@ -46,7 +53,7 @@ jobs:
           ./build.sh -v ${{ matrix.version }} -l
           DDEV_VERSION=${{ matrix.version }} bash bats tests
       -
-        name: Login to GitHub Container Registry
+        name: Login to GitHub Packages Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       -
         name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Docker info
         run: docker info
@@ -31,10 +31,12 @@ jobs:
       -
         name: Setup bats and bats libs
         id: setup-bats
-        uses: bats-core/bats-action@3.0.0
-      -
-        name: Check out code
-        uses: actions/checkout@v1
+        uses: bats-core/bats-action@3.0.1
+        with:
+          support-path: "${{ github.workspace }}/tests/bats-support"
+          assert-path: "${{ github.workspace }}/tests/bats-assert"
+          detik-path: "${{ github.workspace }}/tests/bats-detik"
+          file-path: "${{ github.workspace }}/tests/bats-file"
       -
         name: "Test ddev ${{ matrix.version }} image"
         shell: 'script -q -e -c "bash {0}"'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ Available options:
 | ./build.sh -v v1.23   | v1.23, v1.23.x (latest bugfix) |
 | ...                   | ...                            |
 
-The image is stored on the [GitHub Package Registry](https://github.com/ddev/ddev-gitlab-ci/pkgs/container/ddev-gitlab-ci)
+The image is stored on the [GitHub Packages Registry](https://github.com/ddev/ddev-gitlab-ci/pkgs/container/ddev-gitlab-ci)
+
+> [!NOTE]
+> `GITHUB_TOKEN` needs additional configuration https://github.com/orgs/community/discussions/26274#discussioncomment-3251137:
+> Head over to $yourOrganization → Packages → $yourPackage → Package settings (to the right / bottom)
+> And configure “Manage Actions access” section to allow the git repository in question write permissions on this package/docker repository
 
 ### Run tests locally
 

--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,6 @@ LOAD=""
 IMAGE_NAME="ghcr.io/ddev/ddev-gitlab-ci"
 DDEV_VERSION=""
 
-# @todo:
-#   * --push --load options
-#   * Use bats for tests?!
-
 help() {
     echo "Available options:"
     echo "  * v - DDEV version e.g. 'v1.23.1'"
@@ -98,5 +94,9 @@ fi
 
 echo $DDEV_VERSION
 echo $DOCKER_TAGS
+
+# https://docs.docker.com/build/building/variables/#buildx_no_default_attestations
+# buildx creates extra manifests that we don't need
+export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 
 docker buildx build ${PLATFORM} --progress plain --no-cache --pull . -f Dockerfile ${DOCKER_TAGS[@]} --build-arg ddev_version="$DDEV_VERSION" $PUSH $LOAD


### PR DESCRIPTION
## The Issue

- #19

## How This PR Solves The Issue

- Sets [`BUILDX_NO_DEFAULT_ATTESTATIONS=1`](https://docs.docker.com/build/building/variables/#buildx_no_default_attestations), these provenance attestations created some of the untagged images (extra manifests).
  (Untagged images are still created by design, but now they only match the tags that have been created.)
- Fixes warnings from `bats` by using caching
  (`Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2`)
- Runs build on push only for the actual changes (not for README.md changes).
- Adds a note about `GITHUB_TOKEN` setup to the README.md

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

