### PR TITLE
fix: remove no-bind-mounts from tests and documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,8 @@ jobs:
         name: Docker info
         run: docker info
       -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
       -
         name: Setup bats and bats libs
         id: setup-bats

--- a/docs/gitlab-com.md
+++ b/docs/gitlab-com.md
@@ -20,8 +20,6 @@ ddev-initialize:
     - name: docker:dind
   when: always
   script:
-    # Fix for: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /builds/*/*'
-    - ddev config global --no-bind-mounts=true
     - ddev --version
     # ... do things
 ```

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -42,11 +42,10 @@ setup() {
 
 @test "Create and run a ddev project" {
     local TEST_COMMAND="
-        mkdir ~/ddev-test
-        cd ~/ddev-test
+        mkdir -p /mnt/ddev-shared/ddev-test
+        cd /mnt/ddev-shared/ddev-test
         echo '<?php echo \"Hello World\";' > index.php
         ddev config --project-type php --auto
-        ddev config global --no-bind-mounts=true
         ddev start
         curl https://ddev-test.ddev.site/index.php
         ddev poweroff
@@ -66,13 +65,11 @@ setup() {
     assert_success
 }
 
-# Use "--no-bind-mounts=true" to make "ddev debug test" pass. This is only required in testing environment
 @test "Run ddev debug test" {
     local TEST_COMMAND="
-      mkdir ~/ddev-test
-      cd ~/ddev-test
+      mkdir -p /mnt/ddev-shared/ddev-test-debug
+      cd /mnt/ddev-shared/ddev-test-debug
       ddev config --project-type php --auto
-      ddev config global --no-bind-mounts=true
       ddev debug test
     "
     run docker-run "${TEST_COMMAND}"
@@ -84,5 +81,9 @@ setup() {
 docker-run() {
   local COMMAND=${1}
 
-  docker run --rm -it --network ddev-docker ghcr.io/ddev/ddev-gitlab-ci:"${DDEV_VERSION}" /bin/sh -c "${COMMAND}"
+  # Mount the shared volume to make bind mounts work
+  docker run --rm -it \
+    --network ddev-docker \
+    -v "ddev-shared-volume:/mnt/ddev-shared" \
+    ghcr.io/ddev/ddev-gitlab-ci:"${DDEV_VERSION}" /bin/sh -c "${COMMAND}"
 }


### PR DESCRIPTION
## The Issue

Tests in the GitHub Workflow, as well as the instructions for use on Gitlab.com, contain references to enabling --no-bind-mounts=true for DDEV. However, on Gitlab.com this isn't needed, and for the workflow it's easily solvable via a docker volume.

## How This PR Solves The Issue

Remove the reference from the Gitlab.com docs
Add a Docker volume that is mounted to the DIND container, as well as the DDEV container, and updating the tests to use that volume.

## Manual Testing Instructions

Run the GitHub tests workflow. PR run: https://github.com/AkibaAT/ddev-gitlab-ci/actions/runs/14601086994
Push a simple test project to Gitlab.com. PR run: https://gitlab.com/ddev-testing/ddev-ci-test/-/jobs/9774214049

## Automated Testing Overview

Added volume in `setup_suite.bash`, mounted to `/mnt/ddev-shared`

Adapted existing tests:
- Create and run a ddev project
Moved workdir to `/mnt/ddev-shared/ddev-test`
Removed `ddev config global --no-bind-mounts=true`
- Run ddev debug test
Moved workdir to `/mnt/ddev-shared/ddev-test-debug`
Removed `ddev config global --no-bind-mounts=true`

## Related Issue Link(s)

## Release/Deployment Notes

none

