### PR TITLE
build: add `ddev-hostname` and run actions on `workflow_dispatch`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - ".github/workflows/build.yml"
   schedule:
     - cron: "0 1 * * 1"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,16 @@ name: Test
 
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches:
       - '**'
       - '!main'
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
 jobs:
   build:
     name: Build and Test Container

--- a/ddev-install.sh
+++ b/ddev-install.sh
@@ -40,6 +40,7 @@ else
 fi
 
 mv ddev/ddev /usr/local/bin/
+mv ddev/ddev-hostname /usr/local/bin/ddev-hostname
 mv ddev/mkcert /usr/local/bin/
 sudo -u ddev /usr/local/bin/mkcert -install
 rm -Rf ddev*

--- a/ddev-install.sh
+++ b/ddev-install.sh
@@ -39,9 +39,9 @@ else
   LAST_STARTED_VERSION=${DDEV_VERSION}
 fi
 
-mv ddev/ddev /usr/local/bin/
+mv ddev/ddev /usr/local/bin/ddev
 mv ddev/ddev-hostname /usr/local/bin/ddev-hostname
-mv ddev/mkcert /usr/local/bin/
+mv ddev/mkcert /usr/local/bin/mkcert
 sudo -u ddev /usr/local/bin/mkcert -install
 rm -Rf ddev*
 


### PR DESCRIPTION
## The Issue

Impossible to run build manually.
v1.24.7 was never built.

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

