### PR TITLE
test: refactor bats

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -11,7 +11,7 @@ setup() {
 @test "See docker version" {
   run docker-run "docker version --format '{{.Client.Version}}'"
   assert_success
-  assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+$'
+  assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+'
 }
 
 @test "See ddev --version" {
@@ -45,7 +45,6 @@ setup() {
   assert_success
   assert_output --partial "Configuration complete. You may now run 'ddev start'"
   assert_output --partial "Hello World"
-  assert_success
 }
 
 @test "Run ddev debug dockercheck" {
@@ -65,13 +64,14 @@ setup() {
   run docker-run "${TEST_COMMAND}"
   assert_success
   assert_output --partial "Successfully started tryddevproject-"
-  assert_success
 }
 
 docker-run() {
   # Mount the shared volume to make bind mounts work
   docker run --rm -it \
     --network ddev-docker \
+    -e "DDEV_CI=true" \
+    -e "DDEV_NO_INSTRUMENTATION=true" \
     -v "ddev-shared-volume:/mnt/ddev-shared" \
     ghcr.io/ddev/ddev-gitlab-ci:"${DDEV_VERSION}" /bin/sh -c "${1}"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -9,81 +9,69 @@ setup() {
 }
 
 @test "See docker version" {
-    run docker-run "docker version -f json"
-
-    version=$(echo "$output" | yq .Client.Version)
-    regex='^([0-9]+)\.([0-9]+)\.([0-9]+)$'
-
-    [[ $version =~ $regex ]]
-    [ "$status" -eq 0 ]
+  run docker-run "docker version --format '{{.Client.Version}}'"
+  assert_success
+  assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+$'
 }
 
-@test "See ddev version" {
-    run docker-run "ddev version -j"
-    version=$(echo "$output" | tail -n 1 | yq '.raw.["DDEV version"]')
-
-    if [ "$DDEV_VERSION" = "latest" ]; then
-      # The HEAD version contains a hash e.g. v1.24.1-4-gbce95e65e
-      regex='^v([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)-([a-z0-9]+)$'
-    else
-      regex='^v([0-9]+)\.([0-9]+)\.([0-9]+)$'
-    fi
-
-    [[ $version =~ $regex ]]
-    [ "$status" -eq 0 ]
+@test "See ddev --version" {
+  run docker-run "ddev --version"
+  assert_success
+  if [ "$DDEV_VERSION" = "latest" ]; then
+    # The HEAD version contains a hash e.g. v1.24.1-4-gbce95e65e
+    assert_output --regexp 'v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9]+'
+  else
+    assert_output --regexp 'v[0-9]+\.[0-9]+\.[0-9]+'
+  fi
 }
 
 @test "See mkcert is installed" {
-    run docker-run "mkcert -help"
-
-    assert_output --partial "Usage of mkcert:"
-    assert_success
+  run docker-run "mkcert -help"
+  assert_success
+  assert_output --partial "Usage of mkcert:"
 }
 
 @test "Create and run a ddev project" {
-    local TEST_COMMAND="
-        mkdir -p /mnt/ddev-shared/ddev-test
-        cd /mnt/ddev-shared/ddev-test
-        echo '<?php echo \"Hello World\";' > index.php
-        ddev config --project-type php --auto
-        ddev start
-        curl https://ddev-test.ddev.site/index.php
-        ddev poweroff
-    "
-    run docker-run "${TEST_COMMAND}"
-
-    assert_output --partial "Configuration complete. You may now run 'ddev start'"
-    assert_output --partial "Hello World"
-    assert_success
+  local TEST_COMMAND="
+    mkdir -p /mnt/ddev-shared/ddev-test
+    cd /mnt/ddev-shared/ddev-test
+    echo '<?php echo \"Hello World\";' > index.php
+    ddev config --project-type php --auto
+    ddev start
+    curl https://ddev-test.ddev.site/index.php
+    ddev poweroff
+  "
+  run docker-run "${TEST_COMMAND}"
+  assert_success
+  assert_output --partial "Configuration complete. You may now run 'ddev start'"
+  assert_output --partial "Hello World"
+  assert_success
 }
 
 @test "Run ddev debug dockercheck" {
-    run docker-run "ddev debug dockercheck"
-
-    assert_output --partial "Able to run simple container that mounts a volume."
-    assert_output --partial "Able to use internet inside container."
-    assert_success
+  run docker-run "ddev debug dockercheck"
+  assert_success
+  assert_output --partial "Able to run simple container that mounts a volume."
+  assert_output --partial "Able to use internet inside container."
 }
 
 @test "Run ddev debug test" {
-    local TEST_COMMAND="
-      mkdir -p /mnt/ddev-shared/ddev-test-debug
-      cd /mnt/ddev-shared/ddev-test-debug
-      ddev config --project-type php --auto
-      ddev debug test
-    "
-    run docker-run "${TEST_COMMAND}"
-
-    assert_output --partial "Successfully started tryddevproject-"
-    assert_success
+  local TEST_COMMAND="
+    mkdir -p /mnt/ddev-shared/ddev-test-debug
+    cd /mnt/ddev-shared/ddev-test-debug
+    ddev config --project-type php --auto
+    ddev debug test
+  "
+  run docker-run "${TEST_COMMAND}"
+  assert_success
+  assert_output --partial "Successfully started tryddevproject-"
+  assert_success
 }
 
 docker-run() {
-  local COMMAND=${1}
-
   # Mount the shared volume to make bind mounts work
   docker run --rm -it \
     --network ddev-docker \
     -v "ddev-shared-volume:/mnt/ddev-shared" \
-    ghcr.io/ddev/ddev-gitlab-ci:"${DDEV_VERSION}" /bin/sh -c "${COMMAND}"
+    ghcr.io/ddev/ddev-gitlab-ci:"${DDEV_VERSION}" /bin/sh -c "${1}"
 }


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev-gitlab-ci/actions/runs/21902133823/job/63232866814

```
not ok 1 See docker version
# (in test file tests/test.bats, line 14)
#   `version=$(echo "$output" | yq .Client.Version)' failed
# Error: bad file '-': yaml: line 2: mapping values are not allowed in this context
```

## How This PR Solves The Issue

I don't understand what's going on here, because bats don't show full output.

This PR refactors Bats to give more reliable output.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

